### PR TITLE
feat: make bufferDistinct flushable by another obs

### DIFF
--- a/packages/blueflag-rxjs/README.md
+++ b/packages/blueflag-rxjs/README.md
@@ -144,10 +144,12 @@ zipDiff(obsA, obsB, itemA => itemA.id)
 
 Buffers items while the given predicate function returns the same thing, and emits the buffer contents when the given predicate function returns something else or the stream closes. Value comparison is performed using `Object.is()`.
 
+If `flushObs` is passed, the buffer will be flushed any time `flushObs` emits.
+
 ```js
 import {bufferDistinct} from 'blueflag-rxjs/operators';
 
-bufferDistinct(item => comparisonValue)
+bufferDistinct(item => comparisonValue, flushObs: ?Observable)
 ```
 
 ```js

--- a/packages/blueflag-rxjs/src/operators/__tests__/bufferDistinct-test.js
+++ b/packages/blueflag-rxjs/src/operators/__tests__/bufferDistinct-test.js
@@ -74,4 +74,32 @@ describe('bufferDistinct', () => {
         });
     });
 
+    it('bufferDistinct should accept flushObs and flush buffer when flushObs emits', () => {
+
+        const testScheduler = new TestScheduler((actual, expected) => {
+            expect(actual).toEqual(expected);
+        });
+
+        testScheduler.run(helpers => {
+            const {cold, expectObservable, expectSubscriptions} = helpers;
+
+            const e1 =  cold('-a-a-b-b-----c-|');
+            const e2 =  cold('---------x-y---|');
+            const subs =     '^--------------!';
+            const expected = '-----A---X-----(C|)';
+
+            const values = {
+                A: ['a','a'],
+                X: ['b','b'],
+                C: ['c']
+            };
+
+            expectObservable(
+                e1.pipe(bufferDistinct(value => value, e2))
+            ).toBe(expected, values);
+
+            expectSubscriptions(e1.subscriptions).toBe(subs);
+        });
+    });
+
 });

--- a/packages/blueflag-rxjs/src/operators/bufferDistinct.js
+++ b/packages/blueflag-rxjs/src/operators/bufferDistinct.js
@@ -4,30 +4,41 @@ import {Observable} from 'rxjs';
 type Value = any;
 type Predicate = (value: Value) => any;
 
-export default (predicate: Predicate) => (source: Observable): Observable => {
+export default (predicate: Predicate, flushObs: ?Observable) => (source: Observable): Observable => {
     return Observable.create(subscriber => {
 
         let buffer: Value[] = [];
-        let first: boolean = true;
+        let blank: boolean = true;
         let prevComparisonValue: any = undefined;
+
+        let flush = () => {
+            if(buffer.length > 0) {
+                subscriber.next(buffer);
+                buffer = [];
+            }
+        };
+
+        if(flushObs) {
+            flushObs.subscribe(() => {
+                flush();
+                blank = true;
+            });
+        }
 
         return source.subscribe(
             (value: Value) => {
                 let comparisonValue: any = predicate(value);
-                if(!first && !Object.is(comparisonValue, prevComparisonValue)) {
-                    subscriber.next(buffer);
-                    buffer = [];
+                if(!blank && !Object.is(comparisonValue, prevComparisonValue)) {
+                    flush();
                 }
 
                 buffer.push(value);
                 prevComparisonValue = comparisonValue;
-                first = false;
+                blank = false;
             },
             (err) => subscriber.error(err),
             () => {
-                if(buffer.length > 0) {
-                    subscriber.next(buffer);
-                }
+                flush();
                 subscriber.complete();
             }
         );


### PR DESCRIPTION
```
bufferDistinct((value) => value.something, flushObs?)
```

If `flushObs` is passed, the buffer will be flushed any time `flushObs` emits.